### PR TITLE
(feature) Adds ModelScope as a configurable checkpoint source

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,4 +34,4 @@ jobs:
 
     - name: Run CI tests
       run: |
-        python -m pytest tests/test_imports.py tests/test_interfaces.py tests/test_utils.py tests/test_vision_unit.py tests/test_tts_unit.py tests/test_download.py -v
+        python -m pytest tests/test_imports.py tests/test_interfaces.py tests/test_utils.py tests/test_vision_unit.py tests/test_tts_unit.py tests/test_download.py tests/test_checkpoint_source.py -v

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get update && apt-get install -y python3 python3-pip ffmpeg libsm6 libxe
 # Pin torch to CUDA 12.8 to match the base image (default wheel needs a newer driver).
 RUN pip install --break-system-packages torch torchvision --index-url https://download.pytorch.org/whl/cu128
 
-RUN pip install --break-system-packages .
+RUN pip install --break-system-packages ".[modelscope]"
 
 # clean up source
 RUN rm -rf /roboml

--- a/Dockerfile.Jetson
+++ b/Dockerfile.Jetson
@@ -14,7 +14,7 @@ COPY . .
 RUN apt-get update && apt-get install -y ffmpeg libsm6 libxext6 && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Override pip index to PyPI (base image defaults to unreachable pypi.jetson-ai-lab.dev).
-RUN pip3 install -i https://pypi.org/simple --extra-index-url https://pypi.ngc.nvidia.com .
+RUN pip3 install -i https://pypi.org/simple --extra-index-url https://pypi.ngc.nvidia.com ".[modelscope]"
 # Force numpy<2 — the base image's PyTorch was compiled against NumPy 1.x
 # and crashes with NumPy 2.x. Must be done after install since pip's resolver
 # ignores the pin due to transitive dependencies requiring numpy>=2.

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ RoboML is an aggregator package for quickly deploying open-source ML models for 
 
 ## Models And Wrappers
 
-| **Model Class**    | **Description**                                                                                                                           | **Default Checkpoint / Resource**                                                                                                                         | **Key Init Parameters**                                                                               |
-| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------- |
-| `TransformersLLM`  | General-purpose large language model (LLM) from [🤗 Transformers](https://github.com/huggingface/transformers)                            | [`Qwen/Qwen3-0.6B`](https://huggingface.co/models?other=LLM)                                                                             | `name`, `checkpoint`, `quantization`, `init_timeout`                                                  |
-| `TransformersMLLM` | Multimodal vision-language model (MLLM) from [🤗 Transformers](https://github.com/huggingface/transformers)                               | [`Qwen/Qwen2.5-VL-3B-Instruct`](https://huggingface.co/models?pipeline_tag=image-text-to-text)                                                              | `name`, `checkpoint`, `quantization`, `init_timeout`                                                  |
-| `RoboBrain2`       | Embodied planning + multimodal reasoning via [RoboBrain 2.0](https://github.com/FlagOpen/RoboBrain2.0)                                    | [`BAAI/RoboBrain2.0-3B`](https://huggingface.co/collections/BAAI/robobrain20-6841eeb1df55c207a4ea0036)                                                    | `name`, `checkpoint`, `init_timeout`                                                                  |
-| `Whisper`          | Multilingual speech-to-text (ASR) from [OpenAI Whisper](https://openai.com/index/whisper)                                                 | `small.en` ([checkpoint list](https://github.com/SYSTRAN/faster-whisper/blob/d3bfd0a305eb9d97c08047c82149c1998cc90fcb/faster_whisper/transcribe.py#L606)) | `name`, `checkpoint`, `compute_type`, `init_timeout`                                                  |
-| `TransformersTTS`  | Text-to-speech via [🤗 Transformers](https://huggingface.co/models?pipeline_tag=text-to-speech) (Bark, VITS, SpeechT5, SeamlessM4T, etc.) | [`suno/bark-small`](https://huggingface.co/models?pipeline_tag=text-to-speech)                                                                            | `name`, `checkpoint`, `voice`, `vocoder_checkpoint`, `init_timeout`                                   |
-| `VisionModel`      | Detection + tracking via [🤗 Transformers](https://huggingface.co/models?pipeline_tag=object-detection)                                   | [`PekingU/rtdetr_r50vd_coco_o365`](https://huggingface.co/models?pipeline_tag=object-detection)                                                         | `name`, `checkpoint`, `setup_trackers`, `tracking_distance_threshold`, `num_trackers`, `init_timeout` |
+| **Model Class**    | **Description**                                                                                                                           | **Default Checkpoint / Resource**                                                                                                                         | **Key Init Parameters**                                                                                         |
+| ------------------ | ----------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `TransformersLLM`  | General-purpose large language model (LLM) from [🤗 Transformers](https://github.com/huggingface/transformers)                            | [`Qwen/Qwen3-0.6B`](https://huggingface.co/models?other=LLM)                                                                                              | `name`, `checkpoint`, `quantization`, `source`, `init_timeout`                                                  |
+| `TransformersMLLM` | Multimodal vision-language model (MLLM) from [🤗 Transformers](https://github.com/huggingface/transformers)                               | [`Qwen/Qwen2.5-VL-3B-Instruct`](https://huggingface.co/models?pipeline_tag=image-text-to-text)                                                            | `name`, `checkpoint`, `quantization`, `source`, `init_timeout`                                                  |
+| `RoboBrain2`       | Embodied planning + multimodal reasoning via [RoboBrain 2.0](https://github.com/FlagOpen/RoboBrain2.0)                                    | [`BAAI/RoboBrain2.0-3B`](https://huggingface.co/collections/BAAI/robobrain20-6841eeb1df55c207a4ea0036)                                                    | `name`, `checkpoint`, `source`, `init_timeout`                                                                  |
+| `Whisper`          | Multilingual speech-to-text (ASR) from [OpenAI Whisper](https://openai.com/index/whisper)                                                 | `small.en` ([checkpoint list](https://github.com/SYSTRAN/faster-whisper/blob/d3bfd0a305eb9d97c08047c82149c1998cc90fcb/faster_whisper/transcribe.py#L606)) | `name`, `checkpoint`, `compute_type`, `source`, `init_timeout`                                                  |
+| `TransformersTTS`  | Text-to-speech via [🤗 Transformers](https://huggingface.co/models?pipeline_tag=text-to-speech) (Bark, VITS, SpeechT5, SeamlessM4T, etc.) | [`suno/bark-small`](https://huggingface.co/models?pipeline_tag=text-to-speech)                                                                            | `name`, `checkpoint`, `voice`, `vocoder_checkpoint`, `source`, `init_timeout`                                   |
+| `VisionModel`      | Detection + tracking via [🤗 Transformers](https://huggingface.co/models?pipeline_tag=object-detection)                                   | [`PekingU/rtdetr_r50vd_coco_o365`](https://huggingface.co/models?pipeline_tag=object-detection)                                                           | `name`, `checkpoint`, `setup_trackers`, `tracking_distance_threshold`, `num_trackers`, `source`, `init_timeout` |
 
 ## Installation
 
@@ -52,6 +52,31 @@ virtualenv venv && source venv/bin/activate
 pip install pip-tools
 pip install .
 ```
+
+## Model Checkpoints from ModelScope
+
+By default, RoboML downloads model checkpoints from the [HuggingFace Hub](https://huggingface.co/models). However, users can pull checkpoints from [ModelScope (魔搭社区)](https://modelscope.cn) instead. First install the optional dependency (the Docker images below already include it):
+
+```bash
+pip install "roboml[modelscope]"
+```
+
+Then either set the source globally when starting the server:
+
+```bash
+ROBOML_SOURCE=modelscope roboml
+# or with Docker: docker run -e ROBOML_SOURCE=modelscope ...
+```
+
+or per model, by passing `source: "modelscope"` in the body of the model's `/initialize` call. An explicit `source` parameter always overrides the environment variable.
+
+ModelScope checkpoints are cached in `~/.cache/modelscope` (configurable via `MODELSCOPE_CACHE`), so the cache mount shown in the Docker section covers them as well.
+
+Most default checkpoints are available on ModelScope under the same IDs they have on the HuggingFace Hub, and Whisper size aliases such as `small.en` are resolved automatically. If a checkpoint cannot be found on ModelScope, model initialization fails with a descriptive error that suggests a suitable alternative checkpoint whenever one is known.
+
+Some checkpoints are restricted on ModelScope (e.g. `BAAI/RoboBrain2.0-*`) and cannot be downloaded anonymously. For these, set the `MODELSCOPE_API_TOKEN` environment variable with an access token from your [ModelScope account](https://modelscope.cn/my/myaccesstoken).
+
+Models that only exist on HuggingFace Hub can still be reached by routing HF downloads through a mirror, e.g. `HF_ENDPOINT=https://hf-mirror.com` (a community-run proxy; must be set before the server starts). This works independently of `ROBOML_SOURCE`, since every model node can choose its own `source`.
 
 ## Vision Model Support
 

--- a/docs/README.zh-CN.md
+++ b/docs/README.zh-CN.md
@@ -55,6 +55,31 @@ pip install pip-tools
 pip install .
 ```
 
+## 从魔搭（ModelScope）下载模型检查点
+
+RoboML 默认从 [HuggingFace Hub](https://huggingface.co/models) 下载模型检查点。中国大陆用户可以改从 [魔搭社区（ModelScope）](https://modelscope.cn) 下载。首先安装可选依赖（下文介绍的 Docker 镜像已包含该依赖）：
+
+```bash
+pip install "roboml[modelscope]"
+```
+
+然后可以在启动服务时通过环境变量全局设置下载源：
+
+```bash
+ROBOML_SOURCE=modelscope roboml
+# Docker 方式：docker run -e ROBOML_SOURCE=modelscope ...
+```
+
+也可以针对单个模型，在调用 `/initialize` 时在请求体中传入 `source: "modelscope"`。显式传入的 `source` 参数始终优先于环境变量。
+
+ModelScope 检查点缓存在 `~/.cache/modelscope`（可通过 `MODELSCOPE_CACHE` 环境变量修改），因此 Docker 部分所示的缓存挂载同样适用。
+
+大多数默认检查点在 ModelScope 上使用与 HuggingFace Hub 相同的 ID，Whisper 的尺寸别名（如 `small.en`）也会自动解析。如果某个检查点在 ModelScope 上不可用，模型初始化会失败并给出清晰的错误提示，并在已知的情况下推荐可用的替代检查点（例如文本转语音可使用 `microsoft/speecht5_tts`）。
+
+部分模型在 ModelScope 上受限（如 `BAAI/RoboBrain2.0-*`），无法匿名下载。此类模型需要设置 `MODELSCOPE_API_TOKEN` 环境变量，访问令牌可在 [ModelScope 账号设置](https://modelscope.cn/my/myaccesstoken) 中获取。
+
+仅存在于 HuggingFace Hub 的模型，也可以通过镜像站下载，例如在启动服务前设置 `HF_ENDPOINT=https://hf-mirror.com`（社区维护的镜像代理，需在服务启动前设置）。该设置与 `ROBOML_SOURCE` 相互独立，每个模型节点都可以选择自己的 `source`。
+
 ## 支持视觉模型
 
 VisionModel 使用 HuggingFace Transformers 进行物体检测和跟踪。支持任意 [HuggingFace 物体检测模型](https://huggingface.co/models?pipeline_tag=object-detection)（RT-DETR、DETR、Grounding DINO、YOLOS 等），并内置 [ByteTrack](https://github.com/roboflow/trackers) 跟踪功能。

--- a/interrogate_badge.svg
+++ b/interrogate_badge.svg
@@ -1,10 +1,10 @@
 <svg width="140" height="20" viewBox="0 0 140 20" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <title>interrogate: 100%</title>
+    <title>interrogate: 90.4%</title>
     <g transform="matrix(1,0,0,1,22,0)">
         <g id="backgrounds" transform="matrix(1.32789,0,0,1,-22.3892,0)">
             <rect x="0" y="0" width="71" height="20" style="fill:rgb(85,85,85);"/>
         </g>
-        <rect x="71" y="0" width="47" height="20" data-interrogate="color" style="fill:#4c1"/>
+        <rect x="71" y="0" width="47" height="20" data-interrogate="color" style="fill:#97CA00"/>
         <g transform="matrix(1.19746,0,0,1,-22.3744,-4.85723e-16)">
             <rect x="0" y="0" width="118" height="20" style="fill:url(#_Linear1);"/>
         </g>
@@ -12,8 +12,8 @@
     <g fill="#fff" text-anchor="middle" font-family="DejaVu Sans,Verdana,Geneva,sans-serif" font-size="110">
         <text x="590" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="610">interrogate</text>
         <text x="590" y="140" transform="scale(.1)" textLength="610">interrogate</text>
-        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="330" data-interrogate="result">100%</text>
-        <text x="1160" y="140" transform="scale(.1)" textLength="330" data-interrogate="result">100%</text>
+        <text x="1160" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="370" data-interrogate="result">90.4%</text>
+        <text x="1160" y="140" transform="scale(.1)" textLength="370" data-interrogate="result">90.4%</text>
     </g>
     <g id="logo-shadow" serif:id="logo shadow" transform="matrix(0.854876,0,0,0.854876,-6.73514,1.732)">
         <g transform="matrix(0.299012,0,0,0.299012,9.70229,-6.68582)">

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,7 @@ requires-python = ">=3.10"
 
 [project.optional-dependencies]
 dev = ["httpx", "pip-tools", "pytest", "pre-commit", "redis", "lark"]
+modelscope = ["modelscope>=1.20"]
 
 [project.scripts]
 roboml = "roboml.main:ray"

--- a/src/roboml/models/llm.py
+++ b/src/roboml/models/llm.py
@@ -1,4 +1,4 @@
-from typing import Optional, AsyncGenerator
+from typing import Literal, Optional, AsyncGenerator
 from queue import Empty
 import asyncio
 
@@ -7,7 +7,7 @@ from PIL.Image import Image
 from transformers import AutoTokenizer, AutoModelForCausalLM, TextIteratorStreamer
 
 from roboml.interfaces import LLMInput
-from roboml.utils import get_quantization_config
+from roboml.utils import get_quantization_config, resolve_checkpoint
 
 from ._base import ModelTemplate
 
@@ -31,6 +31,7 @@ class TransformersLLM(ModelTemplate):
         checkpoint: str = "Qwen/Qwen3-0.6B",
         quantization: Optional[str] = "4bit",
         system_prompt: Optional[str] = "You are a helpful AI assistant.",
+        source: Optional[Literal["huggingface", "modelscope"]] = None,
     ) -> None:
         """Initialize Model.
 
@@ -40,9 +41,13 @@ class TransformersLLM(ModelTemplate):
         :type quantization: Optional[str]
         :param init_chat_prompt:
         :type init_chat_prompt: str
+        :param source: Hub to download the checkpoint from. Defaults to the
+            ROBOML_SOURCE environment variable or huggingface
+        :type source: Optional[Literal["huggingface", "modelscope"]]
         :rtype: None
         """
         self.init_chat_prompt = system_prompt
+        checkpoint = resolve_checkpoint(checkpoint, source, self.logger)
         quantization_config = get_quantization_config(quantization, self.logger)
         self.model = AutoModelForCausalLM.from_pretrained(
             checkpoint,

--- a/src/roboml/models/mllm.py
+++ b/src/roboml/models/mllm.py
@@ -1,4 +1,4 @@
-from typing import Optional, AsyncGenerator
+from typing import Literal, Optional, AsyncGenerator
 
 import torch
 from transformers import (
@@ -10,7 +10,11 @@ from transformers import (
 from PIL.Image import Image
 
 from roboml.interfaces import VLLMInput
-from roboml.utils import get_quantization_config, pre_process_images_to_pil
+from roboml.utils import (
+    get_quantization_config,
+    pre_process_images_to_pil,
+    resolve_checkpoint,
+)
 
 from .llm import TransformersLLM
 
@@ -33,6 +37,7 @@ class TransformersMLLM(TransformersLLM):
         checkpoint: str = "Qwen/Qwen2.5-VL-3B-Instruct",
         quantization: Optional[str] = "4bit",
         system_prompt: Optional[str] = "You are a helpful AI assistant.",
+        source: Optional[Literal["huggingface", "modelscope"]] = None,
     ) -> None:
         """Initialize Model.
 
@@ -42,9 +47,13 @@ class TransformersMLLM(TransformersLLM):
         :type quantization: Optional[str]
         :param history_reset_phrase:
         :type history_reset_phrase: str
+        :param source: Hub to download the checkpoint from. Defaults to the
+            ROBOML_SOURCE environment variable or huggingface
+        :type source: Optional[Literal["huggingface", "modelscope"]]
         :rtype: None
         """
         self.init_chat_prompt = system_prompt
+        checkpoint = resolve_checkpoint(checkpoint, source, self.logger)
         quantization_config = get_quantization_config(quantization, self.logger)
         self.model = AutoModelForImageTextToText.from_pretrained(
             checkpoint,

--- a/src/roboml/models/planning.py
+++ b/src/roboml/models/planning.py
@@ -1,9 +1,17 @@
-import os
 import re
+from typing import Literal, Optional
+
 from transformers import Qwen2_5_VLForConditionalGeneration, AutoProcessor
 
 from roboml.interfaces import PlanningInput
-from roboml.utils import pre_process_images_to_pil
+from roboml.utils import (
+    CheckpointSource,
+    get_checkpoint_source,
+    has_huggingface_credentials,
+    has_modelscope_credentials,
+    pre_process_images_to_pil,
+    resolve_checkpoint,
+)
 
 from ._base import ModelTemplate
 
@@ -28,28 +36,47 @@ class RoboBrain2(ModelTemplate):
     def _initialize(
         self,
         checkpoint: str = "BAAI/RoboBrain2.0-3B",
+        source: Optional[Literal["huggingface", "modelscope"]] = None,
     ) -> None:
         """Initialize Model.
 
         :param checkpoint:
         :type checkpoint: str
-        :param quantization:
-        :type quantization: Optional[str]
-        :param history_reset_phrase:
-        :type history_reset_phrase: str
+        :param source: Hub to download the checkpoint from. Defaults to the
+            ROBOML_SOURCE environment variable or huggingface. The model is
+            gated on HF hub (requires HF_TOKEN); on ModelScope it requires a
+            logged-in account instead (set MODELSCOPE_API_TOKEN)
+        :type source: Optional[Literal["huggingface", "modelscope"]]
         :rtype: None
         """
-        if not os.environ.get("HF_TOKEN"):
+        hub = get_checkpoint_source(source)
+        if (
+            hub == CheckpointSource.HUGGINGFACE.value
+            and not has_huggingface_credentials()
+        ):
             raise ValueError(
                 "This model is gated on HF hub. To use it:\n\n"
                 f"  1. Request access on the model page: https://huggingface.co/{checkpoint}\n"
                 "  2. Set your auth token: export HF_TOKEN='your_token_from_huggingface'\n"
+                "     (or log in once with: huggingface-cli login)\n"
             )
+        elif (
+            hub == CheckpointSource.MODELSCOPE.value
+            and not has_modelscope_credentials()
+        ):
+            raise ValueError(
+                "This model is restricted on ModelScope. To use it:\n\n"
+                "  1. Get an access token from your ModelScope account: "
+                "https://modelscope.cn/my/myaccesstoken\n"
+                "  2. Set the token: export MODELSCOPE_API_TOKEN='your_token_from_modelscope'\n"
+                "     (or log in once with: modelscope login)\n"
+            )
+        resolved_checkpoint = resolve_checkpoint(checkpoint, source, self.logger)
         self.model = Qwen2_5_VLForConditionalGeneration.from_pretrained(
-            checkpoint, dtype="auto"
+            resolved_checkpoint, dtype="auto"
         ).to(self.device)
 
-        self.pre_processor = AutoProcessor.from_pretrained(checkpoint)
+        self.pre_processor = AutoProcessor.from_pretrained(resolved_checkpoint)
 
         # Only 7B+ models support thinking mode
         self.supports_thinking = "3B" not in checkpoint

--- a/src/roboml/models/speech_to_text.py
+++ b/src/roboml/models/speech_to_text.py
@@ -1,11 +1,26 @@
 import base64
+from typing import Literal, Optional
+
 import numpy as np
 
 from faster_whisper import WhisperModel
 
 from roboml.interfaces import SpeechToTextInput
+from roboml.utils import CheckpointSource, get_checkpoint_source, resolve_checkpoint
 
 from ._base import ModelTemplate
+
+
+def _map_size_alias(checkpoint: str) -> str:
+    """Map a faster-whisper size alias (e.g. 'small.en') to its repo ID.
+
+    :param checkpoint:
+    :type checkpoint: str
+    :rtype: str
+    """
+    from faster_whisper.utils import _MODELS
+
+    return _MODELS.get(checkpoint, checkpoint)
 
 
 class Whisper(ModelTemplate):
@@ -17,10 +32,26 @@ class Whisper(ModelTemplate):
         self,
         checkpoint: str = "small.en",
         compute_type: str = "int8",
+        source: Optional[Literal["huggingface", "modelscope"]] = None,
     ) -> None:
         """
         Initializes the model.
+
+        :param checkpoint: Model size alias (e.g. 'small.en'), repo ID or local path
+        :type checkpoint: str
+        :param compute_type:
+        :type compute_type: str
+        :param source: Hub to download the checkpoint from. Defaults to the
+            ROBOML_SOURCE environment variable or huggingface
+        :type source: Optional[Literal["huggingface", "modelscope"]]
+        :rtype: None
         """
+        # For ModelScope, map size aliases to their Systran repo IDs and
+        # download explicitly; faster-whisper only knows how to pull from HF hub
+        if get_checkpoint_source(source) == CheckpointSource.MODELSCOPE.value:
+            checkpoint = resolve_checkpoint(
+                _map_size_alias(checkpoint), source, self.logger
+            )
         self.model = WhisperModel(
             checkpoint,
             device=self.device,

--- a/src/roboml/models/text_to_speech.py
+++ b/src/roboml/models/text_to_speech.py
@@ -1,4 +1,4 @@
-from typing import Optional
+from typing import Literal, Optional
 
 import torch
 from transformers import (
@@ -9,7 +9,7 @@ from transformers import (
 )
 
 from roboml.interfaces import TextToSpeechInput
-from roboml.utils import post_process_audio
+from roboml.utils import post_process_audio, resolve_checkpoint
 
 from ._base import ModelTemplate
 
@@ -37,6 +37,7 @@ class TransformersTTS(ModelTemplate):
         checkpoint: str = "suno/bark-small",
         voice: Optional[str] = "v2/en_speaker_6",
         vocoder_checkpoint: Optional[str] = None,
+        source: Optional[Literal["huggingface", "modelscope"]] = None,
     ) -> None:
         """Initialize TTS model.
         :param checkpoint: HuggingFace model ID
@@ -47,9 +48,15 @@ class TransformersTTS(ModelTemplate):
             If not provided and a spectrogram model is loaded, defaults to
             'microsoft/speecht5_hifigan'.
         :type vocoder_checkpoint: Optional[str]
+        :param source: Hub to download checkpoints from. Defaults to the
+            ROBOML_SOURCE environment variable or huggingface. Note: the default
+            checkpoint is not available on ModelScope, use e.g.
+            microsoft/speecht5_tts instead
+        :type source: Optional[Literal["huggingface", "modelscope"]]
         :rtype: None
         """
         self.voice = voice
+        checkpoint = resolve_checkpoint(checkpoint, source, self.logger)
 
         # Try loading as waveform model first, fall back to spectrogram
         try:
@@ -66,7 +73,11 @@ class TransformersTTS(ModelTemplate):
             self.logger.info(f"Loaded spectrogram model: {checkpoint}")
 
             # Load vocoder for spectrogram models
-            vocoder_id = vocoder_checkpoint or "microsoft/speecht5_hifigan"
+            vocoder_id = resolve_checkpoint(
+                vocoder_checkpoint or "microsoft/speecht5_hifigan",
+                source,
+                self.logger,
+            )
             from transformers import SpeechT5HifiGan
 
             self.vocoder = SpeechT5HifiGan.from_pretrained(vocoder_id).to(self.device)

--- a/src/roboml/models/vision.py
+++ b/src/roboml/models/vision.py
@@ -1,4 +1,4 @@
-from typing import Optional, Union
+from typing import Literal, Optional, Union
 
 import numpy as np
 import supervision as sv
@@ -7,7 +7,7 @@ from trackers import ByteTrackTracker
 from transformers import AutoImageProcessor, AutoModelForObjectDetection
 
 from roboml.interfaces import DetectionInput
-from roboml.utils import pre_process_images_to_pil
+from roboml.utils import pre_process_images_to_pil, resolve_checkpoint
 
 from ._base import ModelTemplate
 
@@ -30,6 +30,7 @@ class VisionModel(ModelTemplate):
         setup_trackers: bool = False,
         num_trackers: int = 1,
         tracking_distance_threshold: int = 30,
+        source: Optional[Literal["huggingface", "modelscope"]] = None,
     ) -> None:
         """Initialize detection model.
         :param checkpoint: HuggingFace model ID for object detection
@@ -40,8 +41,14 @@ class VisionModel(ModelTemplate):
         :type num_trackers: int
         :param tracking_distance_threshold: Distance threshold for tracking
         :type tracking_distance_threshold: int
+        :param source: Hub to download the checkpoint from. Defaults to the
+            ROBOML_SOURCE environment variable or huggingface. Note: the default
+            checkpoint is not available on ModelScope, use e.g.
+            facebook/detr-resnet-50 instead
+        :type source: Optional[Literal["huggingface", "modelscope"]]
         :rtype: None
         """
+        checkpoint = resolve_checkpoint(checkpoint, source, self.logger)
         self.pre_processor = AutoImageProcessor.from_pretrained(checkpoint)
         self.model = AutoModelForObjectDetection.from_pretrained(checkpoint)
         self.model.to(self.device)

--- a/src/roboml/utils.py
+++ b/src/roboml/utils.py
@@ -132,6 +132,44 @@ def get_checkpoint_source(source: Optional[str] = None) -> str:
     return source
 
 
+def has_huggingface_credentials() -> bool:
+    """Check if HuggingFace credentials are available, either through the
+    HF_TOKEN environment variable or a cached `huggingface-cli login`.
+
+    Returns True when credentials cannot be determined, leaving the decision
+    to the download attempt.
+
+    :rtype: bool
+    """
+    if os.environ.get("HF_TOKEN"):
+        return True
+    try:
+        from huggingface_hub import get_token
+
+        return bool(get_token())
+    except Exception:
+        return True
+
+
+def has_modelscope_credentials() -> bool:
+    """Check if ModelScope credentials are available, either through the
+    MODELSCOPE_API_TOKEN environment variable or a cached `modelscope login`.
+
+    Returns True when credentials cannot be determined (e.g. older modelscope
+    versions), leaving the decision to the download attempt.
+
+    :rtype: bool
+    """
+    if os.environ.get("MODELSCOPE_API_TOKEN"):
+        return True
+    try:
+        from modelscope_hub.config import HubConfig
+
+        return bool(HubConfig().token)
+    except Exception:
+        return True
+
+
 def resolve_checkpoint(
     checkpoint: str,
     source: Optional[str] = None,

--- a/src/roboml/utils.py
+++ b/src/roboml/utils.py
@@ -1,6 +1,7 @@
 import base64
 import inspect
 import logging
+import os
 from enum import Enum
 from functools import wraps
 from io import BytesIO
@@ -91,6 +92,96 @@ def post_process_audio(
         return audio_bytes
 
     return base64.b64encode(audio_bytes).decode("utf-8")
+
+
+class CheckpointSource(Enum):
+    """Hub from which model checkpoints are downloaded."""
+
+    HUGGINGFACE = "huggingface"
+    MODELSCOPE = "modelscope"
+
+
+# First-party ModelScope alternatives for default checkpoints
+# that are only available on HuggingFace Hub
+MODELSCOPE_ALTERNATIVES = {
+    "suno/bark-small": "microsoft/speecht5_tts",
+    "suno/bark": "microsoft/speecht5_tts",
+    "PekingU/rtdetr_r50vd_coco_o365": "facebook/detr-resnet-50",
+}
+
+
+def get_checkpoint_source(source: Optional[str] = None) -> str:
+    """Get the effective checkpoint source.
+
+    Precedence: explicit source param > ROBOML_SOURCE env var > huggingface.
+
+    :param source:
+    :type source: Optional[str]
+    :rtype: str
+    """
+    source = (
+        source or os.environ.get("ROBOML_SOURCE") or CheckpointSource.HUGGINGFACE.value
+    )
+    valid_sources = {s.value for s in CheckpointSource}
+    if source not in valid_sources:
+        raise ValueError(
+            f"Invalid checkpoint source '{source}'. "
+            f"Valid values are {sorted(valid_sources)}. "
+            "Check the `source` init parameter or the ROBOML_SOURCE environment variable."
+        )
+    return source
+
+
+def resolve_checkpoint(
+    checkpoint: str,
+    source: Optional[str] = None,
+    logger: logging.Logger = logger,
+) -> str:
+    """Resolve a checkpoint ID to something from_pretrained can load.
+
+    For huggingface the checkpoint ID is passed through unchanged and
+    downloading is left to the underlying library. For modelscope the
+    checkpoint is downloaded with modelscope.snapshot_download and the
+    local directory is returned.
+
+    :param checkpoint:
+    :type checkpoint: str
+    :param source:
+    :type source: Optional[str]
+    :param logger:
+    :type logger: logging.Logger
+    :rtype: str
+    """
+    if get_checkpoint_source(source) != CheckpointSource.MODELSCOPE.value:
+        return checkpoint
+
+    try:
+        from modelscope import snapshot_download
+    except ImportError as e:
+        raise ImportError(
+            "Downloading checkpoints from ModelScope requires the modelscope package. "
+            "Install it with: pip install roboml[modelscope]"
+        ) from e
+
+    logger.info(f"Downloading checkpoint {checkpoint} from ModelScope hub")
+    try:
+        checkpoint_dir = snapshot_download(checkpoint)
+    except Exception as e:
+        hint = MODELSCOPE_ALTERNATIVES.get(checkpoint)
+        hint_msg = (
+            f" '{checkpoint}' is not available on ModelScope. "
+            f"Consider using '{hint}' instead, or set source to 'huggingface'."
+            if hint
+            else (
+                " If the model is restricted on ModelScope, log in by setting "
+                "the MODELSCOPE_API_TOKEN environment variable."
+            )
+        )
+        raise RuntimeError(
+            f"Failed to download checkpoint {checkpoint} from ModelScope.{hint_msg}"
+        ) from e
+    logger.info(f"Checkpoint downloaded to {checkpoint_dir}")
+    return checkpoint_dir
 
 
 class Quantization(Enum):

--- a/tests/test_checkpoint_source.py
+++ b/tests/test_checkpoint_source.py
@@ -1,0 +1,227 @@
+"""CI-safe tests: validate checkpoint source resolution (huggingface/modelscope)."""
+
+import inspect
+import sys
+import types
+
+import pytest
+
+from roboml.utils import (
+    CheckpointSource,
+    MODELSCOPE_ALTERNATIVES,
+    get_checkpoint_source,
+    has_huggingface_credentials,
+    has_modelscope_credentials,
+    resolve_checkpoint,
+)
+
+
+def _fake_hub_config(monkeypatch, token):
+    """Install a fake modelscope_hub.config module with a given cached token."""
+    fake_pkg = types.ModuleType("modelscope_hub")
+    fake_cfg = types.ModuleType("modelscope_hub.config")
+
+    def hub_config():
+        return types.SimpleNamespace(token=token)
+
+    fake_cfg.HubConfig = hub_config
+    fake_pkg.config = fake_cfg
+    monkeypatch.setitem(sys.modules, "modelscope_hub", fake_pkg)
+    monkeypatch.setitem(sys.modules, "modelscope_hub.config", fake_cfg)
+
+
+@pytest.fixture
+def clean_env(monkeypatch):
+    """Ensure ROBOML_SOURCE is not set."""
+    monkeypatch.delenv("ROBOML_SOURCE", raising=False)
+
+
+@pytest.fixture
+def fake_modelscope(monkeypatch):
+    """Inject a fake modelscope module that records download calls."""
+    fake = types.ModuleType("modelscope")
+    calls = []
+
+    def snapshot_download(checkpoint):
+        calls.append(checkpoint)
+        return f"/fake/cache/{checkpoint}"
+
+    fake.snapshot_download = snapshot_download
+    monkeypatch.setitem(sys.modules, "modelscope", fake)
+    return calls
+
+
+class TestGetCheckpointSource:
+    def test_default_is_huggingface(self, clean_env):
+        assert get_checkpoint_source(None) == CheckpointSource.HUGGINGFACE.value
+
+    def test_env_var_sets_source(self, clean_env, monkeypatch):
+        monkeypatch.setenv("ROBOML_SOURCE", "modelscope")
+        assert get_checkpoint_source(None) == CheckpointSource.MODELSCOPE.value
+
+    def test_param_overrides_env(self, clean_env, monkeypatch):
+        monkeypatch.setenv("ROBOML_SOURCE", "modelscope")
+        assert get_checkpoint_source("huggingface") == "huggingface"
+
+    def test_invalid_param_raises(self, clean_env):
+        with pytest.raises(ValueError, match="Invalid checkpoint source"):
+            get_checkpoint_source("not_a_hub")
+
+    def test_invalid_env_var_raises(self, clean_env, monkeypatch):
+        monkeypatch.setenv("ROBOML_SOURCE", "not_a_hub")
+        with pytest.raises(ValueError, match="ROBOML_SOURCE"):
+            get_checkpoint_source(None)
+
+
+class TestResolveCheckpoint:
+    def test_huggingface_passthrough(self, clean_env):
+        assert resolve_checkpoint("Qwen/Qwen3-0.6B", "huggingface") == "Qwen/Qwen3-0.6B"
+
+    def test_default_source_passthrough(self, clean_env):
+        assert resolve_checkpoint("Qwen/Qwen3-0.6B") == "Qwen/Qwen3-0.6B"
+
+    def test_modelscope_returns_local_dir(self, clean_env, fake_modelscope):
+        result = resolve_checkpoint("Qwen/Qwen3-0.6B", "modelscope")
+        assert result == "/fake/cache/Qwen/Qwen3-0.6B"
+        assert fake_modelscope == ["Qwen/Qwen3-0.6B"]
+
+    def test_modelscope_source_from_env(self, clean_env, monkeypatch, fake_modelscope):
+        monkeypatch.setenv("ROBOML_SOURCE", "modelscope")
+        result = resolve_checkpoint("Qwen/Qwen3-0.6B")
+        assert result == "/fake/cache/Qwen/Qwen3-0.6B"
+
+    def test_modelscope_not_installed(self, clean_env, monkeypatch):
+        monkeypatch.setitem(sys.modules, "modelscope", None)
+        with pytest.raises(ImportError, match=r"roboml\[modelscope\]"):
+            resolve_checkpoint("Qwen/Qwen3-0.6B", "modelscope")
+
+    def test_download_failure_raises(self, clean_env, monkeypatch):
+        fake = types.ModuleType("modelscope")
+
+        def failing_download(checkpoint):
+            raise Exception("404 not found")
+
+        fake.snapshot_download = failing_download
+        monkeypatch.setitem(sys.modules, "modelscope", fake)
+
+        with pytest.raises(RuntimeError, match="Failed to download"):
+            resolve_checkpoint("some/unknown-model", "modelscope")
+
+    def test_download_failure_hints_alternative(self, clean_env, monkeypatch):
+        fake = types.ModuleType("modelscope")
+
+        def failing_download(checkpoint):
+            raise Exception("404 not found")
+
+        fake.snapshot_download = failing_download
+        monkeypatch.setitem(sys.modules, "modelscope", fake)
+
+        # defaults known to be missing from ModelScope should suggest alternatives
+        with pytest.raises(RuntimeError, match="microsoft/speecht5_tts"):
+            resolve_checkpoint("suno/bark-small", "modelscope")
+        with pytest.raises(RuntimeError, match="facebook/detr-resnet-50"):
+            resolve_checkpoint("PekingU/rtdetr_r50vd_coco_o365", "modelscope")
+
+    def test_alternatives_cover_known_missing_defaults(self):
+        assert "suno/bark-small" in MODELSCOPE_ALTERNATIVES
+        assert "PekingU/rtdetr_r50vd_coco_o365" in MODELSCOPE_ALTERNATIVES
+
+
+class TestHuggingFaceCredentials:
+    def test_env_token(self, monkeypatch):
+        monkeypatch.setenv("HF_TOKEN", "some-token")
+        assert has_huggingface_credentials() is True
+
+    def test_cached_login_token(self, monkeypatch):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setattr("huggingface_hub.get_token", lambda: "cached-token")
+        assert has_huggingface_credentials() is True
+
+    def test_no_credentials(self, monkeypatch):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setattr("huggingface_hub.get_token", lambda: None)
+        assert has_huggingface_credentials() is False
+
+    def test_undeterminable_defaults_to_true(self, monkeypatch):
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setitem(sys.modules, "huggingface_hub", None)
+        assert has_huggingface_credentials() is True
+
+    def test_robobrain_raises_without_credentials(self, monkeypatch):
+        import logging
+
+        from roboml.models import RoboBrain2
+
+        monkeypatch.delenv("HF_TOKEN", raising=False)
+        monkeypatch.setattr("huggingface_hub.get_token", lambda: None)
+        model = RoboBrain2(logger=logging.getLogger("test"))
+        with pytest.raises(ValueError, match="HF_TOKEN"):
+            model._initialize(source="huggingface")
+
+
+class TestModelScopeCredentials:
+    def test_env_token(self, monkeypatch):
+        monkeypatch.setenv("MODELSCOPE_API_TOKEN", "some-token")
+        assert has_modelscope_credentials() is True
+
+    def test_cached_login_token(self, monkeypatch):
+        monkeypatch.delenv("MODELSCOPE_API_TOKEN", raising=False)
+        _fake_hub_config(monkeypatch, token="cached-token")
+        assert has_modelscope_credentials() is True
+
+    def test_no_credentials(self, monkeypatch):
+        monkeypatch.delenv("MODELSCOPE_API_TOKEN", raising=False)
+        _fake_hub_config(monkeypatch, token=None)
+        assert has_modelscope_credentials() is False
+
+    def test_undeterminable_defaults_to_true(self, monkeypatch):
+        monkeypatch.delenv("MODELSCOPE_API_TOKEN", raising=False)
+        # simulate an older modelscope without the modelscope_hub package
+        monkeypatch.setitem(sys.modules, "modelscope_hub", None)
+        monkeypatch.setitem(sys.modules, "modelscope_hub.config", None)
+        assert has_modelscope_credentials() is True
+
+    def test_robobrain_raises_without_credentials(self, monkeypatch):
+        import logging
+
+        from roboml.models import RoboBrain2
+
+        monkeypatch.delenv("MODELSCOPE_API_TOKEN", raising=False)
+        _fake_hub_config(monkeypatch, token=None)
+        model = RoboBrain2(logger=logging.getLogger("test"))
+        with pytest.raises(ValueError, match="MODELSCOPE_API_TOKEN"):
+            model._initialize(source="modelscope")
+
+
+class TestWhisperAliasMapping:
+    def test_size_alias_maps_to_repo_id(self):
+        from roboml.models.speech_to_text import _map_size_alias
+
+        assert _map_size_alias("small.en") == "Systran/faster-whisper-small.en"
+
+    def test_repo_id_passes_through(self):
+        from roboml.models.speech_to_text import _map_size_alias
+
+        assert (
+            _map_size_alias("Systran/faster-whisper-large-v3")
+            == "Systran/faster-whisper-large-v3"
+        )
+
+
+class TestModelInitSignatures:
+    def test_all_models_accept_source(self):
+        from roboml import models
+
+        for model_cls in (
+            models.TransformersLLM,
+            models.TransformersMLLM,
+            models.RoboBrain2,
+            models.Whisper,
+            models.TransformersTTS,
+            models.VisionModel,
+        ):
+            params = inspect.signature(model_cls._initialize).parameters
+            assert "source" in params, (
+                f"{model_cls.__name__}._initialize is missing the source param"
+            )
+            assert params["source"].default is None

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -62,6 +62,23 @@ def test_llm():
 
 
 @pytest.mark.filterwarnings("ignore::RuntimeWarning")
+def test_llm_from_modelscope():
+    """Test TransformersLLM pulling its checkpoint from ModelScope.
+    Requires the modelscope package (pip install roboml[modelscope])."""
+    pytest.importorskip("modelscope")
+    data = LLMInput(query=[{"role": "user", "content": "Whats up?"}])
+    result = run_model(
+        TransformersLLM,
+        init_kwargs={"source": "modelscope"},
+        inputs=[data],
+        log_output=True,
+    )
+    assert "output" in result
+    assert isinstance(result["output"], str)
+    assert len(result["output"]) > 0
+
+
+@pytest.mark.filterwarnings("ignore::RuntimeWarning")
 def test_mllm(loaded_img):
     """Test TransformersMLLM with default checkpoint."""
     data = VLLMInput(


### PR DESCRIPTION
## Summary

RoboML currently pulls all model checkpoints from HuggingFace Hub. This PR makes the checkpoint source configurable, so users can pull checkpoints from [ModelScope (魔搭社区)](https://modelscope.cn) instead.

- Every model class's `_initialize()` now accepts `source: "huggingface" | "modelscope"` (default: `huggingface`). Since init kwargs flow straight from the `/initialize` request body, this works on both the HTTP and RESP servers with no server changes.
- A global default can be set with the `ROBOML_SOURCE` environment variable — a single `-e ROBOML_SOURCE=modelscope` on `docker run` switches the whole deployment without any client changes. An explicit `source` parameter always overrides the env var.
- `modelscope` is an optional dependency (`pip install "roboml[modelscope]"`, lazy-imported). Both Docker images bundle it.

## How it works

`resolve_checkpoint()` (utils) is called at the top of each model's `_initialize()`:

- **huggingface**: checkpoint ID passes through unchanged — zero behavior change for existing users.
- **modelscope**: the checkpoint is downloaded with `modelscope.snapshot_download()` and the local directory (standard HF layout) is handed to `from_pretrained()` / `WhisperModel`. Cached under `~/.cache/modelscope` (`MODELSCOPE_CACHE`).

Model-specific handling:

- **Whisper**: size aliases (`small.en`) are mapped to their `Systran/faster-whisper-*` repo IDs before downloading, since faster-whisper itself only knows how to pull from HF Hub.
- **TransformersTTS**: the vocoder checkpoint is resolved through the same mechanism.
- **RoboBrain2**: the checkpoint is gated on HF Hub and restricted on ModelScope, so the pre-flight credential check is now hub-aware and symmetric: `HF_TOKEN` env var *or* a cached `huggingface-cli login` on one side, `MODELSCOPE_API_TOKEN` *or* a cached `modelscope login` on the other. Both checks fail open when credentials can't be determined, deferring to the download attempt.
- Default checkpoints that don't exist on ModelScope (`suno/bark-small`, `PekingU/rtdetr_r50vd_coco_o365`) fail with an error suggesting first-party alternatives (`microsoft/speecht5_tts`, `facebook/detr-resnet-50`) rather than silently remapping to unofficial re-uploads.

Availability of all default checkpoints on ModelScope was verified against the live hub (July 2026): the Qwen LLM/MLLM defaults, RoboBrain2, faster-whisper and SpeechT5 checkpoints all exist under identical IDs; RoboBrain2 requires a ModelScope login.

## Docs

New "Model Checkpoints from ModelScope" section in the README and its zh-CN mirror: setup, precedence, cache location, restricted checkpoints (`MODELSCOPE_API_TOKEN`), and the `HF_ENDPOINT` mirror escape hatch for HF-only models.
